### PR TITLE
Feat: Add hover highlight to todo - task rows

### DIFF
--- a/frontend/src/components/taskview/todo/CharacterTaskView.tsx
+++ b/frontend/src/components/taskview/todo/CharacterTaskView.tsx
@@ -33,7 +33,7 @@ export const CharacterTaskView = (props: CharacterTaskViewProps) => {
       {tasks.map((task) => {
         return (
           <div
-            className="w-full flex flex-row hover:bg-base-300 pl-4 transition-colors"
+            className="w-full flex flex-row items-center rounded-md hover:bg-base-300 pl-4 pr-2 transition-colors"
             key={`CharacterTaskView-${task.name}-${character.id}`}
           >
             <div className="flex-grow">{task.name}</div>

--- a/frontend/src/components/taskview/todo/CharacterTaskView.tsx
+++ b/frontend/src/components/taskview/todo/CharacterTaskView.tsx
@@ -28,17 +28,24 @@ export const CharacterTaskView = (props: CharacterTaskViewProps) => {
   }
 
   return (
-    <div className='w-full flex flex-col my-1'>
-      <div className='w-full font-semibold text-lg'>{characterName}</div>
-      {
-        tasks.map((task) => {
-          return (<div className='w-full flex flex-row pl-4' key={`CharacterTaskView-${task.name}-${character.id}`}>
-            <div className='flex-grow'>{task.name}</div>
-            <input type="checkbox" className="checkbox checkbox-sm" checked={task.clearTimes.length >= task.maxClearCount} onChange={checkBoxOnClickCurryFunc(task)}/>
+    <div className="w-full flex flex-col my-1">
+      <div className="w-full font-semibold text-lg">{characterName}</div>
+      {tasks.map((task) => {
+        return (
+          <div
+            className="w-full flex flex-row hover:bg-base-300 pl-4 transition-colors"
+            key={`CharacterTaskView-${task.name}-${character.id}`}
+          >
+            <div className="flex-grow">{task.name}</div>
+            <input
+              type="checkbox"
+              className="checkbox checkbox-sm"
+              checked={task.clearTimes.length >= task.maxClearCount}
+              onChange={checkBoxOnClickCurryFunc(task)}
+            />
           </div>
-          )
-        })
-      }
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Closes #1

This PR adds a visual highlight to a task row when hovered over. This makes it clearer which row is being targeted for the checkbox.

Changes:
- Added Tailwind CSS utility classes (hover:bg-base-200, transition-colors) to the parent div of each task row.
- The classes uses base so it's theme-aware of both light and dark modes.


It's an alternative to the PR #6 by @damondriscoll . This is just my take on addressing the issue. Either change works for me, it's just something I'd like to hash out on my free time while addressing a common issue. 

I appreciate the work done on this project. Thanks to you two!